### PR TITLE
Critical Security Flaw and Schema Correction for Reviews RLS

### DIFF
--- a/supabase/migrations/20241004043333_rls_policies.sql
+++ b/supabase/migrations/20241004043333_rls_policies.sql
@@ -1,5 +1,3 @@
-ALTER TABLE reviews ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
-
 --Table RLS policies
 
 ALTER TABLE public.versions ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20241004043333_rls_policies.sql
+++ b/supabase/migrations/20241004043333_rls_policies.sql
@@ -1,3 +1,5 @@
+ALTER TABLE reviews ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
+
 --Table RLS policies
 
 ALTER TABLE public.versions ENABLE ROW LEVEL SECURITY;
@@ -58,9 +60,11 @@ WITH CHECK (user_id IS NOT NULL);
 CREATE POLICY "Users can only update their own data"
 ON reviews
 FOR UPDATE
-USING (user_id = reviews.user_id);
+USING (auth.uid() = user_id); /* Critical RLS fix */
+-- USING (user_id = reviews.user_id);
 
 CREATE POLICY "Allow select rating"
 ON reviews
 FOR SELECT
 USING (auth.role() = 'anon');
+

--- a/supabase/migrations/20241004043333_rls_policies.sql
+++ b/supabase/migrations/20241004043333_rls_policies.sql
@@ -58,8 +58,7 @@ WITH CHECK (user_id IS NOT NULL);
 CREATE POLICY "Users can only update their own data"
 ON reviews
 FOR UPDATE
-USING (auth.uid() = user_id); /* Critical RLS fix */
--- USING (user_id = reviews.user_id);
+USING (auth.uid() = user_id);
 
 CREATE POLICY "Allow select rating"
 ON reviews

--- a/supabase/migrations/20250802112156_fix_user_id_type.sql
+++ b/supabase/migrations/20250802112156_fix_user_id_type.sql
@@ -1,2 +1,0 @@
-ALTER TABLE reviews
-ALTER COLUMN user_id TYPE uuid USING user_id::uuid;

--- a/supabase/migrations/20250802112156_fix_user_id_type.sql
+++ b/supabase/migrations/20250802112156_fix_user_id_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reviews
+ALTER COLUMN user_id TYPE uuid USING user_id::uuid;

--- a/supabase/migrations/20250802113100_fix_review_policies_and_type.sql
+++ b/supabase/migrations/20250802113100_fix_review_policies_and_type.sql
@@ -1,0 +1,24 @@
+-- Drop existing policies on the 'reviews' table to allow for the column type change(TEXT to uUID)
+DROP POLICY IF EXISTS "Users can only insert their own data" ON reviews;
+DROP POLICY IF EXISTS "Users can only update their own data" ON reviews;
+DROP POLICY IF EXISTS "Allow select rating" ON reviews;
+
+-- Alter the user_id column(TEXT to UUID)
+ALTER TABLE reviews
+ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
+
+-- UPDATE all policies.
+CREATE POLICY "Users can only insert their own data"
+ON reviews
+FOR INSERT
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can only update their own data"
+ON reviews
+FOR UPDATE
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Allow select rating"
+ON reviews
+FOR SELECT
+USING (auth.role() = 'anon');


### PR DESCRIPTION
This PR fixes a security issue and a schema mismatch in the reviews table of the marketplace backend.

### **What was wrong?**

1.  **Security Vulnerability:** The `reviews` table's Row Level Security (RLS) policy was incorrectly configured, allowing any authenticated user to update or delete any review (Provided they knew their Use ID). The `FOR UPDATE` policy was checking against `user_id = reviews.user_id`, a condition that is always true.

2.  **Schema Inconsistency:** The `user_id` column in the `reviews` table was improperly defined as a `TEXT` data type instead of a `UUID`, causing a data type mismatch with Supabase's `auth.uid()` function.

3.  **Migration Dependency Conflict:** The attempt to fix the schema by altering the column type failed due to existing RLS policies depending on the old data type, creating a dependency loop.

### **Solution..**

-   **Multi-Step Migration:** A new, comprehensive migration was created to resolve the dependency conflict. This migration correctly and safely performs the following sequence:

    1.  Drops all existing RLS policies on the `reviews` table.

    2.  Alters the `user_id` column's data type from `TEXT` to `UUID`. 

    3.  Re-creates all RLS policies (`INSERT`, `UPDATE`, `SELECT`) with the correct, secure logic and data types.

-   **Corrected RLS Policy:** The `FOR UPDATE` policy was updated to `USING (auth.uid() = user_id)`, ensuring that a user can now only modify their own reviews.

### **Validation**

The successful execution of `supabase migration up` confirms that all database schema changes and RLS policies have been applied correctly. The local Supabase instance is now in a secure and consistent state — ready for further development!!